### PR TITLE
Remove tomcat.servlet.* metrics

### DIFF
--- a/tomcat/ci/tomcat.yaml
+++ b/tomcat/ci/tomcat.yaml
@@ -17,6 +17,10 @@ instances:
 
 # List of metrics to be collected by the integration
 # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+#
+# Note: Be very careful with tomcat.servlet.* jmx metrics, as they will provide metrics per jsp.
+# This easily leads to an huge amount of data points being send to StackState.
+
 init_config:
   conf:
     - include:
@@ -51,18 +55,6 @@ init_config:
             metric_type: gauge
           processingTime:
             alias: tomcat.processing_time
-            metric_type: counter
-    - include:
-        j2eeType: Servlet
-        attribute:
-          processingTime:
-            alias: tomcat.servlet.processing_time
-            metric_type: counter
-          errorCount:
-            alias: tomcat.servlet.error_count
-            metric_type: counter
-          requestCount:
-            alias: tomcat.servlet.request_count
             metric_type: counter
     - include:
         type: Cache

--- a/tomcat/conf.yaml.example
+++ b/tomcat/conf.yaml.example
@@ -16,6 +16,10 @@ instances:
   #     newTag: test
 
 # List of metrics to be collected by the integration
+
+# Note: Be very careful with tomcat.servlet.* jmx metrics, as they will provide metrics per jsp.
+# This easily leads to an huge amount of data points being send to StackState.
+
 init_config:
   conf:
     - include:
@@ -50,18 +54,6 @@ init_config:
             metric_type: gauge
           processingTime:
             alias: tomcat.processing_time
-            metric_type: counter
-    - include:
-        j2eeType: Servlet
-        attribute:
-          processingTime:
-            alias: tomcat.servlet.processing_time
-            metric_type: counter
-          errorCount:
-            alias: tomcat.servlet.error_count
-            metric_type: counter
-          requestCount:
-            alias: tomcat.servlet.request_count
             metric_type: counter
     - include:
         type: Cache


### PR DESCRIPTION
Remove tomcat.servlet.* metrics, as this will send alot of datapoints… to StackState.

Observed around 50k datapoints within 6 hours, for tomcat.servlet.processing_time alone.
