### PR TITLE
Splunk Topology using a session key

### DIFF
--- a/splunk_event/test_splunk_event.py
+++ b/splunk_event/test_splunk_event.py
@@ -12,7 +12,7 @@ def _mocked_saved_searches(*args, **kwargs):
     return []
 
 def _mocked_auth_session(instance_key):
-    return "sessionKey1"
+    return
 
 class TestSplunkErrorResponse(AgentCheckTest):
     """
@@ -254,7 +254,7 @@ class TestSplunkEarliestTimeAndDuplicates(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": test_data["sid"]}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
             return MockedResponse()
@@ -454,14 +454,14 @@ class TestSplunkContinueAfterRestart(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "empty"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
             if test_data["latest_time"] is None:
-                self.assertTrue('dispatch.latest_time' not in args[2])
+                self.assertTrue('dispatch.latest_time' not in args[1])
             elif test_data["latest_time"] != "":
-                self.assertEquals(args[2]['dispatch.latest_time'], test_data["latest_time"])
+                self.assertEquals(args[1]['dispatch.latest_time'], test_data["latest_time"])
 
             return MockedResponse()
 
@@ -539,14 +539,14 @@ class TestSplunkQueryInitialHistory(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "events"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
             if test_data["latest_time"] is None:
-                self.assertTrue('dispatch.latest_time' not in args[2])
+                self.assertTrue('dispatch.latest_time' not in args[1])
             elif test_data["latest_time"] != "":
-                self.assertEquals(args[2]['dispatch.latest_time'], test_data["latest_time"])
+                self.assertEquals(args[1]['dispatch.latest_time'], test_data["latest_time"])
 
             return MockedResponse()
 
@@ -618,7 +618,7 @@ class TestSplunkMaxRestartTime(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "empty"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
@@ -684,7 +684,7 @@ class TestSplunkKeepTimeOnFailure(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "events"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
@@ -749,7 +749,7 @@ class TestSplunkAdvanceTimeOnSuccess(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "events"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
@@ -859,6 +859,7 @@ class TestSplunkSavedSearchesError(AgentCheckTest):
         thrown = False
         try:
             self.run_check(config, mocks={
+                '_auth_session': _mocked_auth_session,
                 '_saved_searches': _mocked_saved_searches
             })
         except CheckException:
@@ -928,6 +929,8 @@ class TestSplunkEventRespectParallelDispatches(AgentCheckTest):
                 expected = "savedsearch%i" % self.expected_sid_increment
                 self.assertEquals(result, expected)
                 self.expected_sid_increment += 1
+
+            return True
 
         self.run_check(config, mocks={
             '_auth_session': _mocked_auth_session,

--- a/splunk_metric/test_splunk_metric.py
+++ b/splunk_metric/test_splunk_metric.py
@@ -418,7 +418,7 @@ class TestSplunkEarliestTimeAndDuplicates(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": test_data["sid"]}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
             return MockedResponse()
@@ -556,14 +556,14 @@ class TestSplunkContinueAfterRestart(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "empty"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
             if test_data["latest_time"] is None:
-                self.assertTrue('dispatch.latest_time' not in args[2])
+                self.assertTrue('dispatch.latest_time' not in args[1])
             elif test_data["latest_time"] != "":
-                self.assertEquals(args[2]['dispatch.latest_time'], test_data["latest_time"])
+                self.assertEquals(args[1]['dispatch.latest_time'], test_data["latest_time"])
 
             return MockedResponse()
 
@@ -641,14 +641,14 @@ class TestSplunkQueryInitialHistory(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "minimal_metrics"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
             if test_data["latest_time"] is None:
-                self.assertTrue('dispatch.latest_time' not in args[2])
+                self.assertTrue('dispatch.latest_time' not in args[1])
             elif test_data["latest_time"] != "":
-                self.assertEquals(args[2]['dispatch.latest_time'], test_data["latest_time"])
+                self.assertEquals(args[1]['dispatch.latest_time'], test_data["latest_time"])
 
             return MockedResponse()
 
@@ -720,7 +720,7 @@ class TestSplunkMaxRestartTime(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "empty"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
@@ -786,7 +786,7 @@ class TestSplunkKeepTimeOnFailure(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "minimal_metrics"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
@@ -851,7 +851,7 @@ class TestSplunkAdvanceTimeOnSuccess(AgentCheckTest):
             class MockedResponse():
                 def json(self):
                     return {"sid": "minimal_metrics"}
-            earliest_time = args[2]['dispatch.earliest_time']
+            earliest_time = args[1]['dispatch.earliest_time']
             if test_data["earliest_time"] != "":
                 self.assertEquals(earliest_time, test_data["earliest_time"])
 
@@ -1006,6 +1006,8 @@ class TestSplunkMetricRespectParallelDispatches(AgentCheckTest):
                 expected = "savedsearch%i" % self.expected_sid_increment
                 self.assertEquals(result, expected)
                 self.expected_sid_increment += 1
+
+            return True
 
         self.run_check(config, mocks={
             '_auth_session': _mocked_auth_session,

--- a/splunk_topology/check.py
+++ b/splunk_topology/check.py
@@ -92,6 +92,8 @@ class SplunkTopology(AgentCheck):
 
         self.start_snapshot(instance_key)
         try:
+            instance.instance_config.set_auth_session_key(self._auth_session(instance.instance_config))
+
             saved_searches = self._saved_searches(instance.instance_config)
             instance.saved_searches.update_searches(self.log, saved_searches)
 
@@ -150,7 +152,7 @@ class SplunkTopology(AgentCheck):
         :return: search id
         """
         dispatch_url = '%s/services/saved/searches/%s/dispatch' % (instance_config.base_url, quote(saved_search.name))
-        auth = instance_config.get_auth_tuple()
+        auth_session_key = instance_config.get_auth_session_key()
 
         parameters = saved_search.parameters
         # json output_mode is mandatory for response parsing
@@ -158,7 +160,7 @@ class SplunkTopology(AgentCheck):
 
         self.log.debug("Dispatching saved search: %s." % saved_search.name)
 
-        response_body = self.splunkHelper.do_post(dispatch_url, auth, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
+        response_body = self.splunkHelper.do_post(dispatch_url, auth_session_key, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
         return response_body['sid']
 
     def _extract_components(self, instance, result):
@@ -202,3 +204,7 @@ class SplunkTopology(AgentCheck):
             if key not in self.EXCLUDE_FIELDS:
                 result[key] = value
         return result
+
+    def _auth_session(self, instance_config):
+        """ This method is mocked for testing. Do not change its behavior """
+        return self.splunkHelper.auth_session(instance_config)

--- a/splunk_topology/check.py
+++ b/splunk_topology/check.py
@@ -92,7 +92,7 @@ class SplunkTopology(AgentCheck):
 
         self.start_snapshot(instance_key)
         try:
-            instance.instance_config.set_auth_session_key(self._auth_session(instance.instance_config))
+            self._auth_session(instance.instance_config)
 
             saved_searches = self._saved_searches(instance.instance_config)
             instance.saved_searches.update_searches(self.log, saved_searches)
@@ -152,7 +152,6 @@ class SplunkTopology(AgentCheck):
         :return: search id
         """
         dispatch_url = '%s/services/saved/searches/%s/dispatch' % (instance_config.base_url, quote(saved_search.name))
-        auth_session_key = instance_config.get_auth_session_key()
 
         parameters = saved_search.parameters
         # json output_mode is mandatory for response parsing
@@ -160,7 +159,7 @@ class SplunkTopology(AgentCheck):
 
         self.log.debug("Dispatching saved search: %s." % saved_search.name)
 
-        response_body = self.splunkHelper.do_post(dispatch_url, auth_session_key, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
+        response_body = self.splunkHelper.do_post(dispatch_url, parameters, saved_search.request_timeout_seconds, instance_config.verify_ssl_certificate).json()
         return response_body['sid']
 
     def _extract_components(self, instance, result):
@@ -207,4 +206,4 @@ class SplunkTopology(AgentCheck):
 
     def _auth_session(self, instance_config):
         """ This method is mocked for testing. Do not change its behavior """
-        return self.splunkHelper.auth_session(instance_config)
+        self.splunkHelper.auth_session(instance_config)

--- a/splunk_topology/test_splunk_topology.py
+++ b/splunk_topology/test_splunk_topology.py
@@ -10,6 +10,9 @@ FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'ci')
 def _mocked_saved_searches(*args, **kwargs):
     return []
 
+def _mocked_auth_session(instance_key):
+    return "sessionKey1"
+
 class TestSplunkNoTopology(AgentCheckTest):
     """
     Splunk check should work in absence of topology
@@ -31,7 +34,7 @@ class TestSplunkNoTopology(AgentCheckTest):
                 }
             ]
         }
-        self.run_check(config, mocks={'_saved_searches':_mocked_saved_searches})
+        self.run_check(config, mocks={'_saved_searches':_mocked_saved_searches, '_auth_session': _mocked_auth_session})
         instances = self.check.get_topology_instances()
         self.assertEqual(len(instances), 1)
 
@@ -82,7 +85,8 @@ class TestSplunkTopology(AgentCheckTest):
         self.run_check(config, mocks={
             '_dispatch_saved_search': _mocked_dispatch_saved_search,
             '_search': _mocked_search,
-            '_saved_searches': _mocked_saved_searches
+            '_saved_searches': _mocked_saved_searches,
+            '_auth_session': _mocked_auth_session
         })
 
         instances = self.check.get_topology_instances()
@@ -166,7 +170,8 @@ class TestSplunkMinimalTopology(AgentCheckTest):
         self.run_check(config, mocks={
             '_dispatch_saved_search': _mocked_dispatch_saved_search,
             '_search': _mocked_minimal_search,
-            '_saved_searches': _mocked_saved_searches
+            '_saved_searches': _mocked_saved_searches,
+            '_auth_session': _mocked_auth_session
         })
 
         instances = self.check.get_topology_instances()
@@ -244,7 +249,8 @@ class TestSplunkIncompleteTopology(AgentCheckTest):
             self.run_check(config, mocks={
                 '_dispatch_saved_search': _mocked_dispatch_saved_search,
                 '_search': _mocked_incomplete_search,
-                '_saved_searches': _mocked_saved_searches
+                '_saved_searches': _mocked_saved_searches,
+                '_auth_session': _mocked_auth_session
             })
         except CheckException:
             thrown = True
@@ -323,7 +329,8 @@ class TestSplunkTopologyPollingInterval(AgentCheckTest):
             '_dispatch_saved_search': _mocked_dispatch_saved_search,
             '_search': _mocked_interval_search,
             '_current_time_seconds': _mocked_current_time_seconds,
-            '_saved_searches': _mocked_saved_searches
+            '_saved_searches': _mocked_saved_searches,
+            '_auth_session': _mocked_auth_session
         }
 
         # Inital run
@@ -399,7 +406,8 @@ class TestSplunkTopologyErrorResponse(AgentCheckTest):
             self.run_check(config, mocks={
                 '_dispatch_saved_search': _mocked_dispatch_saved_search,
                 '_search': _mocked_search,
-                '_saved_searches': _mocked_saved_searches
+                '_saved_searches': _mocked_saved_searches,
+                '_auth_session': _mocked_auth_session
             })
         except CheckException:
             thrown = True
@@ -492,7 +500,8 @@ class TestTopologyDataIsClearedOnFailure(AgentCheckTest):
             self.run_check(config, mocks={
                 '_dispatch_saved_search': _mocked_dispatch_saved_search,
                 '_search': _mocked_search,
-                '_saved_searches': _mocked_saved_searches
+                '_saved_searches': _mocked_saved_searches,
+                '_auth_session': _mocked_auth_session
             })
         except CheckException:
             thrown = True
@@ -551,7 +560,8 @@ class TestSplunkWildcardTopology(AgentCheckTest):
         self.run_check(config, mocks={
             '_dispatch_saved_search': _mocked_dispatch_saved_search,
             '_search': _mocked_search,
-            '_saved_searches': _mocked_saved_searches
+            '_saved_searches': _mocked_saved_searches,
+            '_auth_session': _mocked_auth_session
         })
         instances = self.check.get_topology_instances()
         self.assertEqual(len(instances), 1)
@@ -619,5 +629,6 @@ class TestSplunkTopologyRespectParallelDispatches(AgentCheckTest):
 
         self.run_check(config, mocks={
             '_dispatch_and_await_search': _mock_dispatch_and_await_search,
-            '_saved_searches': _mocked_saved_searches
+            '_saved_searches': _mocked_saved_searches,
+            '_auth_session': _mocked_auth_session
         })


### PR DESCRIPTION
I've done this for telemetry in the previous PR but found out that it didn't work for topology, whoopsie.