### PR TITLE
Allow incomplete data in splunk topology, event and metric checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - SDK_TESTING=true
     - BUNDLE_PATH=$TRAVIS_BUILD_DIR/vendor/cache
-    - DD_AGENT_BRANCH=master
+    - DD_AGENT_BRANCH=stac-1987-continue-topology-on-wrong-data
     - EXTRAS_BRANCH=master
     - JMXFETCH_URL="https://s3-eu-west-1.amazonaws.com/sts-jmxfetch"
     - REQ_LOCALS="$TRAVIS_BUILD_DIR,$HOME/dd-agent,$HOME/integrations-extras"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - SDK_TESTING=true
     - BUNDLE_PATH=$TRAVIS_BUILD_DIR/vendor/cache
-    - DD_AGENT_BRANCH=stac-1987-continue-topology-on-wrong-data
+    - DD_AGENT_BRANCH=master
     - EXTRAS_BRANCH=master
     - JMXFETCH_URL="https://s3-eu-west-1.amazonaws.com/sts-jmxfetch"
     - REQ_LOCALS="$TRAVIS_BUILD_DIR,$HOME/dd-agent,$HOME/integrations-extras"

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ unless ENV['CI']
   ENV['RUN_VENV'] = 'true'
   ENV['SDK_TESTING'] = 'true'
   ENV['DD_AGENT_REPO'] = 'https://github.com/StackVista/sts-agent.git'
-  ENV['DD_AGENT_BRANCH'] = 'master'
+  ENV['DD_AGENT_BRANCH'] = 'stac-1987-continue-topology-on-wrong-data'
 end
 
 ENV['SDK_HOME'] = File.dirname(__FILE__)

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ unless ENV['CI']
   ENV['RUN_VENV'] = 'true'
   ENV['SDK_TESTING'] = 'true'
   ENV['DD_AGENT_REPO'] = 'https://github.com/StackVista/sts-agent.git'
-  ENV['DD_AGENT_BRANCH'] = 'stac-1987-continue-topology-on-wrong-data'
+  ENV['DD_AGENT_BRANCH'] = 'master'
 end
 
 ENV['SDK_HOME'] = File.dirname(__FILE__)

--- a/splunk_event/README.md
+++ b/splunk_event/README.md
@@ -1,0 +1,1 @@
+This check can be easily tested using https://hub.docker.com/r/stackstate/splunk-test/

--- a/splunk_event/ci/fixtures/partially_incomplete_events.json
+++ b/splunk_event/ci/fixtures/partially_incomplete_events.json
@@ -1,0 +1,15 @@
+{
+	"preview": false,
+	"init_offset": 0,
+	"messages": [],
+	"fields": [{
+		"name": "_time"
+	}],
+	"results": [{
+		"_time": "2017-03-08T12:00:00.000+00:00",
+        "_bkt": "main~2~60326C78-E9E8-45CD-90C3-CF75DB894977",
+        "_cd": "2:49"
+	}, {
+	}],
+	"highlighted": {}
+}

--- a/splunk_metric/README.md
+++ b/splunk_metric/README.md
@@ -1,0 +1,1 @@
+This check can be easily tested using https://hub.docker.com/r/stackstate/splunk-test/

--- a/splunk_metric/ci/fixtures/partially_incomplete_metrics.json
+++ b/splunk_metric/ci/fixtures/partially_incomplete_metrics.json
@@ -1,0 +1,15 @@
+{
+	"preview": false,
+	"init_offset": 0,
+	"messages": [],
+	"fields": [],
+	"results": [{
+		"_time": "2017-03-08T12:00:00.000+00:00",
+        "_bkt": "main~2~60326C78-E9E8-45CD-90C3-CF75DB894977",
+        "_cd": "2:49",
+        "value": 1.0,
+        "metric": "metric_name"
+	}, {
+	}],
+	"highlighted": {}
+}

--- a/splunk_topology/README.md
+++ b/splunk_topology/README.md
@@ -1,0 +1,1 @@
+This check can be easily tested using https://hub.docker.com/r/stackstate/splunk-test/

--- a/splunk_topology/ci/fixtures/partially_incomplete_components.json
+++ b/splunk_topology/ci/fixtures/partially_incomplete_components.json
@@ -5,14 +5,17 @@
   "fields": [
     {
       "name": "id"
+    },
+    {
+      "name": "type"
     }
   ],
   "results": [
     {
-      "id": "vm_2_1"
+      "id": "vm_2_1",
+      "type": "vm"
     },
     {
-      "id": "server_2"
     }
   ],
   "highlighted": {}

--- a/splunk_topology/ci/fixtures/partially_incomplete_relations.json
+++ b/splunk_topology/ci/fixtures/partially_incomplete_relations.json
@@ -5,14 +5,22 @@
   "fields": [
     {
       "name": "id"
+    },
+    {
+      "name": "sourceId"
+    },
+    {
+      "name": "targetId"
     }
   ],
   "results": [
     {
-      "id": "vm_2_1"
+
     },
     {
-      "id": "server_2"
+      "type": "HOSTED_ON",
+      "sourceId": "vm_2_1",
+      "targetId": "server_2"
     }
   ],
   "highlighted": {}


### PR DESCRIPTION
This MR makes the splunk_topology, event and metric checks more forgiving when incorrect data is presented form splunk side.

When incorrect dat ais encountered on a saved search a service_check with WARNING severity is presented