### PR TITLE
Default dispatch parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - SDK_TESTING=true
     - BUNDLE_PATH=$TRAVIS_BUILD_DIR/vendor/cache
-    - DD_AGENT_BRANCH=master
+    - DD_AGENT_BRANCH=default_splunk_parameters
     - EXTRAS_BRANCH=master
     - JMXFETCH_URL="https://s3-eu-west-1.amazonaws.com/sts-jmxfetch"
     - REQ_LOCALS="$TRAVIS_BUILD_DIR,$HOME/dd-agent,$HOME/integrations-extras"

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ unless ENV['CI']
   ENV['RUN_VENV'] = 'true'
   ENV['SDK_TESTING'] = 'true'
   ENV['DD_AGENT_REPO'] = 'https://github.com/StackVista/sts-agent.git'
-  ENV['DD_AGENT_BRANCH'] = 'master'
+  ENV['DD_AGENT_BRANCH'] = 'default_splunk_parameters'
 end
 
 ENV['SDK_HOME'] = File.dirname(__FILE__)

--- a/splunk_event/check.py
+++ b/splunk_event/check.py
@@ -45,7 +45,11 @@ class SplunkEvent(SplunkTelemetryBase):
             'default_max_query_chunk_seconds': 3600,
             'default_initial_delay_seconds': 0,
             'default_unique_key_fields': ["_bkt", "_cd"],
-            'default_app': "search"
+            'default_app': "search",
+            'default_parameters': {
+                "force_dispatch": True,
+                "dispatch.now": True
+            }
         })
         saved_searches = []
         if instance['saved_searches'] is not None:

--- a/splunk_event/conf.yaml.example
+++ b/splunk_event/conf.yaml.example
@@ -37,7 +37,12 @@ init_config:
   #   - "_cd"
 
   # the Splunk app in where the saved searches are located
-  default_app: "search"
+  # default_app: "search"
+
+  # default parameters for the Splunk saved search query, these parameters make sure the query refreshes.
+  default_parameters:
+    force_dispatch: true
+    dispatch.now: true
 
 # Currently it is not possible to specify multiple instances with the same url.
 # It is possible to specify multiple saved_searches on a single instance.
@@ -64,12 +69,9 @@ instances:
         # unique_key_fields:
         #   - "_bkt"
         #   - "_cd"
-
-        # Additional parameters for the splunk saved search query
-        parameters:
-          # These parameters make sure the query refreshes.
-          force_dispatch: true
-          dispatch.now: true
+        # parameters:
+        #   force_dispatch: true
+        #   dispatch.now: true
 
     # tags:
     #      - optional_tag1

--- a/splunk_event/test_splunk_event.py
+++ b/splunk_event/test_splunk_event.py
@@ -1211,7 +1211,7 @@ class TestSplunkEventSearchFullFailure(AgentCheckTest):
     Splunk metric check should fail when all saved searches fail
     """
 
-    CHECK_NAME = 'splunk_metric'
+    CHECK_NAME = 'splunk_event'
 
     def test_checks(self):
         self.maxDiff = None
@@ -1256,3 +1256,123 @@ class TestSplunkEventSearchFullFailure(AgentCheckTest):
             thrown = True
 
         self.assertTrue(thrown, "All saved searches should fail and an exception should've been thrown")
+
+
+class TestSplunkDefaults(AgentCheckTest):
+    CHECK_NAME = 'splunk_event'
+
+    def test_default_parameters(self):
+        """
+        when no default parameters are provided, the code should provide the parameters
+        """
+        config = {
+            'init_config': {},
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "events"
+                    }],
+                    'tags': ["checktag:checktagvalue"]
+                }
+            ]
+        }
+        expected_default_parameters = {'dispatch.now': True, 'force_dispatch': True}
+
+        def _mocked_auth_session_to_check_instance_config(instance):
+            for saved_search in instance.saved_searches.searches:
+                self.assertEqual(saved_search.parameters, expected_default_parameters, msg="Unexpected default parameters for saved search: %s" % saved_search.name)
+            return "sessionKey1"
+
+        self.run_check(config, mocks={
+            '_auth_session': _mocked_auth_session_to_check_instance_config,
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_full_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.events), 2)
+
+
+    def test_non_default_parameters(self):
+        """
+        when non default parameters are provided, the code should respect them.
+        """
+        config = {
+            'init_config': {
+                'default_parameters': {
+                    'respect': 'me'
+                }
+            },
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "events"
+                    }],
+                    'tags': ["checktag:checktagvalue"]
+                }
+            ]
+        }
+        expected_default_parameters = {'respect': 'me'}
+
+        def _mocked_auth_session_to_check_instance_config(instance):
+            for saved_search in instance.saved_searches.searches:
+                self.assertEqual(saved_search.parameters, expected_default_parameters, msg="Unexpected non-default parameters for saved search: %s" % saved_search.name)
+            return "sessionKey1"
+
+        self.run_check(config, mocks={
+            '_auth_session': _mocked_auth_session_to_check_instance_config,
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_full_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+        self.assertEqual(len(self.events), 2)
+
+
+    def test_overwrite_default_parameters(self):
+        """
+        when default parameters are overwritten, the code should respect them.
+        """
+        config = {
+            'init_config': {
+                'init_config': {
+                    'default_parameters': {
+                        'default_should': 'be ignored'
+                    }
+                },
+            },
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "events",
+                        "parameters": {
+                            "respect": "me"
+                        }
+                    }],
+                    'tags': ["checktag:checktagvalue"]
+                }
+            ]
+        }
+
+        expected_default_parameters = {'respect': 'me'}
+
+        def _mocked_auth_session_to_check_instance_config(instance):
+            for saved_search in instance.saved_searches.searches:
+                self.assertEqual(saved_search.parameters, expected_default_parameters, msg="Unexpected overwritten parameters for saved search: %s" % saved_search.name)
+            return "sessionKey1"
+
+        self.run_check(config, mocks={
+            '_auth_session': _mocked_auth_session_to_check_instance_config,
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_full_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+        self.assertEqual(len(self.events), 2)

--- a/splunk_metric/check.py
+++ b/splunk_metric/check.py
@@ -62,7 +62,11 @@ class SplunkMetric(SplunkTelemetryBase):
             'default_max_query_chunk_seconds': 3600,
             'default_initial_delay_seconds': 0,
             'default_unique_key_fields': ["_bkt", "_cd"],
-            'default_app': "search"
+            'default_app': "search",
+            'default_parameters': {
+                "force_dispatch": True,
+                "dispatch.now": True
+            }
         })
         saved_searches = []
         if instance['saved_searches'] is not None:

--- a/splunk_metric/conf.yaml.example
+++ b/splunk_metric/conf.yaml.example
@@ -43,6 +43,11 @@ init_config:
   # the Splunk app in where the saved searches are located
   default_app: "search"
 
+  # default parameters for the Splunk saved search query, these parameters make sure the query refreshes.
+  default_parameters:
+    force_dispatch: true
+    dispatch.now: true
+
 # Currently it is not possible to specify multiple instances with the same url.
 # It is possible to specify multiple saved_searches on a single instance.
 instances:
@@ -71,12 +76,9 @@ instances:
         # unique_key_fields:
         #   - "_bkt"
         #   - "_cd"
-
-        # Additional parameters for the splunk saved search query
-        parameters:
-          # These parameters make sure the query refreshes.
-          force_dispatch: true
-          dispatch.now: true
+        # parameters:
+        #   force_dispatch: true
+        #   dispatch.now: true
 
     # tags:
     #      - optional_tag1

--- a/splunk_metric/test_splunk_metric.py
+++ b/splunk_metric/test_splunk_metric.py
@@ -1350,3 +1350,125 @@ class TestSplunkAllFieldsForIdentification(AgentCheckTest):
         })
 
         self.assertEqual(len(self.metrics), 0)
+
+
+class TestSplunkDefaults(AgentCheckTest):
+    CHECK_NAME = 'splunk_metric'
+
+    def test_default_parameters(self):
+        """
+        when no default parameters are provided, the code should provide the parameters
+        """
+        config = {
+            'init_config': {},
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "minimal_metrics"
+                    }],
+                    'tags': []
+                }
+            ]
+        }
+
+        expected_default_parameters = {'dispatch.now': True, 'force_dispatch': True}
+
+        def _mocked_auth_session_to_check_instance_config(instance):
+            for saved_search in instance.saved_searches.searches:
+                self.assertEqual(saved_search.parameters, expected_default_parameters, msg="Unexpected default parameters for saved search: %s" % saved_search.name)
+            return "sessionKey1"
+
+        self.run_check(config, mocks={
+            '_auth_session': _mocked_auth_session_to_check_instance_config,
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.metrics), 2)
+
+
+    def test_non_default_parameters(self):
+        """
+        when non default parameters are provided, the code should respect them.
+        """
+        config = {
+            'init_config': {
+                'default_parameters': {
+                    'respect': 'me'
+                }
+            },
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "minimal_metrics"
+                    }],
+                    'tags': []
+                }
+            ]
+        }
+
+        expected_default_parameters = {'respect': 'me'}
+
+        def _mocked_auth_session_to_check_instance_config(instance):
+            for saved_search in instance.saved_searches.searches:
+                self.assertEqual(saved_search.parameters, expected_default_parameters, msg="Unexpected non-default parameters for saved search: %s" % saved_search.name)
+            return "sessionKey1"
+
+        self.run_check(config, mocks={
+            '_auth_session': _mocked_auth_session_to_check_instance_config,
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.metrics), 2)
+
+
+    def test_overwrite_default_parameters(self):
+        """
+        when default parameters are overwritten, the code should respect them.
+        """
+        config = {
+            'init_config': {
+                'default_parameters': {
+                    'default_should': 'be ignored'
+                }
+            },
+            'instances': [
+                {
+                    'url': 'http://localhost:13001',
+                    'username': "admin",
+                    'password': "admin",
+                    'saved_searches': [{
+                        "name": "minimal_metrics",
+                        "parameters": {
+                            "respect": "me"
+                        }
+                    }],
+                    'tags': []
+                }
+            ]
+        }
+
+        expected_default_parameters = {'respect': 'me'}
+
+        def _mocked_auth_session_to_check_instance_config(instance):
+            for saved_search in instance.saved_searches.searches:
+                self.assertEqual(saved_search.parameters, expected_default_parameters, msg="Unexpected overwritten default parameters for saved search: %s" % saved_search.name)
+            return "sessionKey1"
+
+        self.run_check(config, mocks={
+            '_auth_session': _mocked_auth_session_to_check_instance_config,
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_search,
+            '_saved_searches': _mocked_saved_searches
+        })
+
+        self.assertEqual(len(self.metrics), 2)

--- a/splunk_topology/check.py
+++ b/splunk_topology/check.py
@@ -27,7 +27,11 @@ class InstanceConfig(SplunkInstanceConfig):
             'default_verify_ssl_certificate': False,
             'default_batch_size': 1000,
             'default_saved_searches_parallel': 3,
-            'default_app': "search"
+            'default_app': "search",
+            'default_parameters': {
+                "force_dispatch": True,
+                "dispatch.now": True
+            }
         })
 
         self.default_polling_interval_seconds = init_config.get('default_polling_interval_seconds', 15)

--- a/splunk_topology/conf.yaml.example
+++ b/splunk_topology/conf.yaml.example
@@ -25,6 +25,11 @@ init_config:
   # the Splunk app in where the saved searches are located
   default_app: "search"
 
+  # default parameters for the Splunk saved search query, these parameters make sure the query refreshes.
+  default_parameters:
+    force_dispatch: true
+    dispatch.now: true
+
 
 # Currently it is not possible to specify multiple instances with the same url.
 # It is possible to specify multiple saved_searches on a single instance.
@@ -44,11 +49,9 @@ instances:
         # search_max_retry_count: 5
         # search_seconds_between_retries: 1
         # batch_size: 1000
-
-        # Additional parameters for the splunk saved search query
-        parameters:
-          force_dispatch: true
-          dispatch.now: true
+        # parameters:
+        #   force_dispatch: true
+        #   dispatch.now: true
     relation_saved_searches:
       #- name: "relations"
       # Wilcard match to find relation queries, can be used instead of name

--- a/splunk_topology/test_splunk_topology.py
+++ b/splunk_topology/test_splunk_topology.py
@@ -815,8 +815,7 @@ class TestSplunkDefaults(AgentCheckTest):
             '_search': _mocked_search,
             '_saved_searches': _mocked_saved_searches,
             '_auth_session': _mocked_auth_session_to_check_instance_config
-        }
-        )
+        })
         instances = self.check.get_topology_instances()
         self.assertEqual(len(instances), 1)
 
@@ -856,8 +855,7 @@ class TestSplunkDefaults(AgentCheckTest):
             '_search': _mocked_search,
             '_saved_searches': _mocked_saved_searches,
             '_auth_session': _mocked_auth_session_to_check_instance_config
-        }
-                       )
+        })
         instances = self.check.get_topology_instances()
         self.assertEqual(len(instances), 1)
 
@@ -903,7 +901,6 @@ class TestSplunkDefaults(AgentCheckTest):
             '_search': _mocked_search,
             '_saved_searches': _mocked_saved_searches,
             '_auth_session': _mocked_auth_session_to_check_instance_config
-        }
-                       )
+        })
         instances = self.check.get_topology_instances()
         self.assertEqual(len(instances), 1)


### PR DESCRIPTION
Splunk saved searches were always dispatched with parameters 'dispatch.now' and 'force_dispatch'. This PR removes the requirement of specifying them per saved search and just assume these parameters as default. Now you can just provide a neat list of saved searches.