### PR TITLE
fix and tests for checkException raised

### DIFF
--- a/splunk_topology/check.py
+++ b/splunk_topology/check.py
@@ -196,6 +196,7 @@ class SplunkTopology(AgentCheck):
             if not instance.splunk_ignore_saved_search_errors:
                 raise e
             self.log.warning("Ignoring Check exception as ignore_saved_search_errors flag is true.")
+            self.log.exception("Splunk process saved search exception: %s" % str(e))
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.WARNING, tags=instance.tags, message=str(e))
 
         return True

--- a/splunk_topology/test_splunk_topology.py
+++ b/splunk_topology/test_splunk_topology.py
@@ -1126,6 +1126,12 @@ class TestSplunkContinue(AgentCheckTest):
         self.assertEqual(len(instances), 1)
         # Even second saved search failed but topology reported from first saved search
         self.assertEqual(len(instances[0]['components']), 2)
+        # Check if all components came from first saved search
+        self.assertEqual(instances[0]['components'][0]['externalId'], "vm_2_1")
+        self.assertEqual(instances[0]['components'][0]['type']['name'], "vm")
+        self.assertEqual(instances[0]['components'][1]['externalId'], "server_2")
+        self.assertEqual(instances[0]['components'][1]['type']['name'], "server")
+
         self.assertEquals(len(instances[0]['relations']), 0)
         # second saved search throws a check exception for maximum retries data and report a service check
         self.assertEquals(self.service_checks[0]['status'], 1, "service check should have status AgentCheck.WARNING")
@@ -1180,7 +1186,6 @@ class TestSplunkContinue(AgentCheckTest):
         # second saved search throws a check exception for maximum retries data and report a service check
         self.assertEquals(self.service_checks[0]['status'], 2, "service check should have status AgentCheck.CRITICAL")
 
-
     def test_check_exception_fail_count_continue(self):
         """
         When both saved search fails with Check Exception, the code should continue and send topology.
@@ -1226,6 +1231,9 @@ class TestSplunkContinue(AgentCheckTest):
         # second saved search throws a check exception for maximum retries and report a service check
         self.assertEquals(self.service_checks[1]['status'], 1, "service check should have status AgentCheck.WARNING")
         self.assertEquals(self.service_checks[1]['message'], "maximum retries reached for saved search components12")
+        # Both saved search failed so there should be no components and relations
+        self.assertEqual(len(instance[0]['components']), 0)
+        self.assertEqual(len(instance[0]['relations']), 0)
         # check if the check continued and finished
         self.assertEqual(instance[0]["stop_snapshot"], True)
         self.assertEqual(instance[0]["start_snapshot"], True)

--- a/splunk_topology/test_splunk_topology.py
+++ b/splunk_topology/test_splunk_topology.py
@@ -1113,15 +1113,15 @@ class TestSplunkContinue(AgentCheckTest):
         def _mocked_check_exception_search(*args, **kwargs):
             sid = args[0]
             if sid == "components12":
-                raise CheckException("maximum retries reached for saved search "+ str(sid))
+                raise CheckException("maximum retries reached for saved search " + str(sid))
             return [json.loads(Fixtures.read_file("%s.json" % sid, sdk_dir=FIXTURE_DIR))]
 
         self.run_check(config, mocks={
-                '_dispatch_saved_search': _mocked_dispatch_saved_search,
-                '_search': _mocked_check_exception_search,
-                '_saved_searches': _mocked_saved_searches,
-                '_auth_session': _mocked_auth_session
-            })
+            '_dispatch_saved_search': _mocked_dispatch_saved_search,
+            '_search': _mocked_check_exception_search,
+            '_saved_searches': _mocked_saved_searches,
+            '_auth_session': _mocked_auth_session
+        })
         instances = self.check.get_topology_instances()
         self.assertEqual(len(instances), 1)
         # Even second saved search failed but topology reported from first saved search
@@ -1157,17 +1157,17 @@ class TestSplunkContinue(AgentCheckTest):
         def _mocked_check_exception_search(*args, **kwargs):
             sid = args[0]
             if sid == "components12":
-                raise CheckException("maximum retries reached for saved search "+ str(sid))
+                raise CheckException("maximum retries reached for saved search " + str(sid))
             return [json.loads(Fixtures.read_file("%s.json" % sid, sdk_dir=FIXTURE_DIR))]
         thrown = False
         try:
             self.run_check(config, mocks={
-                    '_dispatch_saved_search': _mocked_dispatch_saved_search,
-                    '_search': _mocked_check_exception_search,
-                    '_saved_searches': _mocked_saved_searches,
-                    '_auth_session': _mocked_auth_session
-                })
-        except Exception as e:
+                '_dispatch_saved_search': _mocked_dispatch_saved_search,
+                '_search': _mocked_check_exception_search,
+                '_saved_searches': _mocked_saved_searches,
+                '_auth_session': _mocked_auth_session
+            })
+        except Exception:
             # Catch exception thrown from check as the ignore_saved_search_errors flag is False
             thrown = True
 
@@ -1205,7 +1205,7 @@ class TestSplunkContinue(AgentCheckTest):
         def _mocked_check_exception_search(*args, **kwargs):
             sid = args[0]
             if sid == "components12":
-                raise CheckException("maximum retries reached for saved search "+ str(sid))
+                raise CheckException("maximum retries reached for saved search " + str(sid))
             return [json.loads(Fixtures.read_file("%s.json" % sid, sdk_dir=FIXTURE_DIR))]
 
         def _mocked_extract_components(*args, **kwargs):

--- a/splunk_topology/test_splunk_topology.py
+++ b/splunk_topology/test_splunk_topology.py
@@ -1139,7 +1139,7 @@ class TestSplunkContinue(AgentCheckTest):
         self.assertEqual(instances[0]["stop_snapshot"], True)
         self.assertEqual(instances[0]["start_snapshot"], True)
 
-    def test_check_exception__false_continue(self):
+    def test_check_exception_false_continue(self):
         """
         When 1 saved search fails with Check Exception, the code should break and clear the whole topology.
         """


### PR DESCRIPTION
Fix done for Check Exception raised inside `process_saved_search` and make sure topology is not cleared if the check continues because of flag `ignore_saved_search_errors` set to `True`.