### PR TITLE
Google Analytics, zero value injection on real time results

### DIFF
--- a/google_analytics/check.py
+++ b/google_analytics/check.py
@@ -72,6 +72,11 @@ class GoogleAnalyticsCheck(AgentCheck):
             # In order to have a consistent metric, we look for the value of one minute ago and not during the last minute.
             rows = result.get('rows', [])
             filtered_rows = filter(lambda row: int(row[minutes_ago_idx]) == 1, rows)
+
+            # The API omits the last minute when no value is available, defaulting to zero value.
+            if not filtered_rows:
+                filtered_rows = [['01', '0']]
+
             result['rows'] = filtered_rows
 
         self.process_response(instance_tags, result)

--- a/google_analytics/test_google_analytics.py
+++ b/google_analytics/test_google_analytics.py
@@ -88,7 +88,7 @@ class TestRealtimeGoogleAnalytics(GoogleAnalytics):
             'get_rt_results': lambda profile_id, metric, dimensions, filters: self._get_json("realtime_one_metric_one_dimension_no_filter_no_minute_value"),
             'get_ga_results': lambda profile_id, metrics, dimensions, filters, start_time, end_time: None
         })
-        self.assertEqual(len(self.metrics), 0, "No metrics should have been collected.")
+        self.assertMetric(metric_name="googleanalytics.rt.pageviews", value=0, tags=['profile:ga:12345678', 'rt.minutesAgo:01'], count=1)
 
     def test_one_metric_empty_results(self):
         self.run_check(self._config([{
@@ -100,7 +100,7 @@ class TestRealtimeGoogleAnalytics(GoogleAnalytics):
             'get_rt_results': lambda profile_id, metric, dimensions, filters: self._get_json("realtime_one_metric_one_dimension_no_filter_no_result"),
             'get_ga_results': lambda profile_id, metrics, dimensions, filters, start_time, end_time: None
         })
-        self.assertEqual(len(self.metrics), 0, "No metrics should have been collected.")
+        self.assertMetric(metric_name="googleanalytics.rt.pageviews", value=0,tags=['profile:ga:12345678', 'rt.minutesAgo:01'], count=1)
 
     def test_one_metric_no_dimension_no_filter(self):
         self.run_check(self._config([{


### PR DESCRIPTION
The Google Analyics (GA) integration for real time queries looks at the value reported of one minute ago.
If there is not value reported back from GA then no value is collected. This PR injects a zero value if the value of last minute is not present.
